### PR TITLE
Fix AsyncRestClient Missing SSL Params

### DIFF
--- a/src/datadog_api_client/rest.py
+++ b/src/datadog_api_client/rest.py
@@ -240,7 +240,7 @@ class AsyncRESTClientObject:
         proxy = None
         if configuration.proxy:
             proxy = aiosonic.Proxy(configuration.proxy, configuration.proxy_headers)
-        self._client = aiosonic.HTTPClient(proxy=proxy)
+        self._client = aiosonic.HTTPClient(proxy=proxy, verify_ssl=configuration.verify_ssl)
         self._configuration = configuration
 
     def _retry(self, method, response, counter):


### PR DESCRIPTION
Configuration arguments aren't correctly passed into the async rest client. This can result in ssl errors even after we've disabled ssl verification in the configuration.

Error Thrown:
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1002)
